### PR TITLE
Window is already defined.

### DIFF
--- a/jquery.ba-postmessage.js
+++ b/jquery.ba-postmessage.js
@@ -54,7 +54,6 @@
     rm_callback,
     
     // A few convenient shortcuts.
-    window = this,
     FALSE = !1,
     
     // Reused internal strings.


### PR DESCRIPTION
Remove window declaration/assignment. Some plugins I've used actually flag this problem.
